### PR TITLE
コミットしないファイルを指定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+y.tab.c
+y.tab.h
+y.output
+*.csb
+keyword.c
+memtest
+prst
+memt
+treet
+meant
+cgent
+disasm
+svm


### PR DESCRIPTION
以下の点からmakeで生成されるファイルをコミットしないようにしました
- 自動生成されるファイルに環境依存なコードが含まれている場合、特定の環境でコンパイルエラーが起こると考えられる
- makeの仕様上、依存ファイルのタイムスタンプによってはターゲットが再度生成されないため、トラブルの原因になると考えられる